### PR TITLE
Use 'apt-get' instead of 'apt' to stop it whinging.

### DIFF
--- a/auto_install.sh
+++ b/auto_install.sh
@@ -32,8 +32,8 @@ function list_games {
 function install_common_dependencies {
     # Add support for 32bit apps
     dpkg --add-architecture i386
-    apt update
-    apt install -y mailutils postfix curl wget file tar bzip2 gzip unzip bsdmainutils python util-linux ca-certificates binutils bc jq tmux
+    apt-get update
+    apt-get install -y mailutils postfix curl wget file tar bzip2 gzip unzip bsdmainutils python util-linux ca-certificates binutils bc jq tmux
 }
 
 function validate_user {


### PR DESCRIPTION
`apt` is definitely a nicer user interface (and a little less typing), but when used in scripts you will see:
```

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

```
To avoid that, just use `apt-get`.