### PR TITLE
Set 'e'

### DIFF
--- a/auto_install.sh
+++ b/auto_install.sh
@@ -92,9 +92,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-[ -z "$GAME" ] && fail "No game selected!"
-[ -z "$GAMEUSER" ] && fail "No user selected!"
-[ -z "$GAMEDIR" ] && GAMEDIR="/home/$GAMEUSER/gameserver"
+[ -n "$GAME" ] || fail "No game selected!"
+[ -n "$GAMEUSER" ] || fail "No user selected!"
+[ -n "$GAMEDIR" ] || GAMEDIR="/home/$GAMEUSER/gameserver"
 
 validate_user
 


### PR DESCRIPTION
I suggest setting 'e' so that the script will exit non-zero if any of the commands fail. 

If you are unfamiliar with "setting 'e'":

> -e (errexit): Abort the script at the first error, when a command exits with non-zero status (except in until or while loops, if-tests, and list constructs

Otherwise, it's possible that the install will fail, but the script still exits 0.

Con:
- Anticipated failures need to be explicitly handled.

Pro:
- Anticipated failures need to be explicitly handled. :stuck_out_tongue_closed_eyes: 

See the bash builtin ['set' doc page](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin) for more info.