### PR TITLE
Update lib32gcc1 name

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ In case the auto installer doesn't install all required dependencies, find the m
 ```shell
 #!/bin/bash
 # Example pre_install.sh script
-apt install -y lib32gcc1 python netcat
+apt install -y lib32gcc1 python3 netcat
 ```
 
 If you created a snapshot of your VM, restore it and try installing the server again with your new script.

--- a/auto_install.sh
+++ b/auto_install.sh
@@ -33,7 +33,7 @@ function install_common_dependencies {
     # Add support for 32bit apps
     dpkg --add-architecture i386
     apt-get update
-    apt-get install -y mailutils postfix curl wget file tar bzip2 gzip unzip bsdmainutils python util-linux ca-certificates binutils bc jq tmux
+    apt-get install -y mailutils postfix curl wget file tar bzip2 gzip unzip bsdmainutils python3 util-linux ca-certificates binutils bc jq tmux iputils2
 }
 
 function validate_user {
@@ -123,7 +123,16 @@ run_as_user "cd \"$GAMEDIR\"; bash linuxgsm.sh \"$GAMESERVER\""
 run_game_script "pre_install.sh"
 
 # Install game dependencies
+# If this script it running in docker, we need to mask it for this command
+if [ -f /.dockerenv ]; then
+    mv /.dockerenv /.dockerenv.tmp
+fi
+
 bash "$GAMEDIR/$GAMESERVER" auto-install
+
+if [ -f /.dockerenv.tmp ]; then
+    mv /.dockerenv.tmp /.dockerenv
+fi
 
 # Install game server
 run_as_user "cd \"$GAMEDIR\"; ./\"$GAMESERVER\" auto-install"

--- a/auto_install.sh
+++ b/auto_install.sh
@@ -32,8 +32,8 @@ function list_games {
 function install_common_dependencies {
     # Add support for 32bit apps
     dpkg --add-architecture i386
-    apt-get update
-    apt-get install -y mailutils postfix curl wget file tar bzip2 gzip unzip bsdmainutils python3 util-linux ca-certificates binutils bc jq tmux iputils2
+    apt update
+    apt install -y mailutils postfix curl wget file tar bzip2 gzip unzip bsdmainutils python3 util-linux ca-certificates binutils bc jq tmux iproute2 netcat xz-utils
 }
 
 function validate_user {

--- a/games/mcb/pre_install.sh
+++ b/games/mcb/pre_install.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-apt install -y lib32gcc1 lib32stdc++6
+for i in lib32gcc1 lib32gcc-s1 lib32stdc++6; do
+  apt install -y "$i"
+done

--- a/games/samp/pre_install.sh
+++ b/games/samp/pre_install.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-apt install -y lib32gcc1 libstdc++6 lib32stdc++6
+for i in lib32gcc1 lib32gcc-s1 lib32stdc++6 libstdc++6; do
+  apt install -y "$i"
+done

--- a/games/ut/pre_install.sh
+++ b/games/ut/pre_install.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-apt install -y lib32gcc1 lib32stdc++6 xz-utils
+for i in lib32gcc-s1 lib32gcc1 lib32stdc++6 xz-utils; do
+  apt install -y "$i"
+done


### PR DESCRIPTION
In newer distributions, lib32gcc1 has been renamed. To ensure backwards compatibility with existing systems, both packages will be tried while installing.